### PR TITLE
Product/Category/Collection SEO Handling

### DIFF
--- a/components/OddularCategoryMeta.tsx
+++ b/components/OddularCategoryMeta.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Head from 'next/head';
+
+const preFetch = (id: string, storeKey: string) => {};
+
+interface OddularCategoryMetaProps {}
+
+const OddularCategoryMeta: React.FC<OddularCategoryMetaProps> = ({}) => {
+  return <></>;
+};
+
+export default OddularCategoryMeta;

--- a/components/OddularCollectionMeta.tsx
+++ b/components/OddularCollectionMeta.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Head from 'next/head';
+
+const preFetch = (id: string, storeKey: string) => {};
+
+interface OddularCollectionMetaProps {}
+
+const OddularCollectionMeta: React.FC<OddularCollectionMetaProps> = ({}) => {
+  return <></>;
+};
+
+export default OddularCollectionMeta;

--- a/components/OddularProductMeta.tsx
+++ b/components/OddularProductMeta.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Head from 'next/head';
+
+const preFetch = (id: string, storeKey: string) => {};
+
+interface OddularProductMetaProps {}
+
+const OddularProductMeta: React.FC<OddularProductMetaProps> = ({}) => {
+  return <></>;
+};
+
+export default OddularProductMeta;

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,7 +14,7 @@ import DisplayBlocks from '../components/DisplayBlocks';
 import ProductCard from '../components/ProductCard';
 
 const TOKEN = '__DEMO__ODDULAR_PUBLIC_TOKEN_00000';
-const GRAPHQL_URL = 'http://localhost:8000/storefront/';
+const GRAPHQL_URL = 'https://api.odd.app/';
 
 export const cartErrorFragment = gql`
   fragment CartError on CartError {

--- a/pages/product/[product_id].tsx
+++ b/pages/product/[product_id].tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { GetServerSideProps } from 'next';
+import { NextPage } from '@lib/types';
+import { Box } from '@chakra-ui/react';
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const data = {};
+  return { props: { data } };
+};
+
+interface ProductPageProps {}
+
+const ProductPage: NextPage<ProductPageProps> = ({}) => {
+  return <Box>hi</Box>;
+};
+
+ProductPage.layout = null;
+export default ProductPage;


### PR DESCRIPTION
I created these stubbed out files to populate with next head components
https://nextjs.org/docs/api-reference/next/head

In the head we'll start with meta tags for all of the things in this tutorial
https://www.netlify.com/blog/2020/05/08/improve-your-seo-and-social-sharing-cards-with-next.js/

we'll want to pass in a Product/Category/Collection object to each component, and then that  component will populate the tags as efficiently as possible. So "product.seo.title" may exist on the object, but if it doesn't then use "product.name", and we'll try to handle all of those the best that we can. 

there is also a "prefetch function" this function will be used to "prefetch" meta data using next js "ServerSideProps" but we'll worry about these after we have the other stuff working-ish.

there is also a "product_id" page this page will be updated to work with all of the above, but we won't worry about it until we have the other stuff working-ish 